### PR TITLE
[FIX][Issues #59] Fix slide behaviour when tab controller is used and…

### DIFF
--- a/lib/src/bar.dart
+++ b/lib/src/bar.dart
@@ -350,7 +350,10 @@ class ConvexAppBarState extends State<ConvexAppBar>
       return;
     }
     if (_tabController.index != _currentIndex) {
-      animateTo(_tabController.index);
+      var _diff = (_tabController.index - _currentIndex).abs();
+      if (_diff == 1) {
+        animateTo(_tabController.index);
+      }
     }
   }
 


### PR DESCRIPTION
This is a pull request where the bad internal behaviour of the tab controller that affects the Convex_bottom bar.

I take into consideration that final user only will use the convex bottom app bar with the tab view and implements the change of the tab view in the convex bottom app bar icons instead of implementing another solution, so with that point in mind, the listener (_handleTabControllerAnimationTick) configured in the tab controller should only be accessible when the user slides the view in the tab view. Only one tab can be slide at the time, so the different (in abs terms) with the current index must be not more than one. So I ask in the routine to check if this difference is only one before animating the icon, else discard the movement. 
I checked and it works correctly, but I'm not sure if this approach fix you design. So, please be free to provide any comments, suggestion or even rejecting the PR. 