### PR TITLE
Fix badge color in chip_builder

### DIFF
--- a/lib/src/chip_builder.dart
+++ b/lib/src/chip_builder.dart
@@ -110,7 +110,7 @@ class DefaultChipBuilder extends ChipBuilder {
             padding: padding,
             child: Container(
               decoration:
-                  BoxDecoration(shape: BoxShape.circle, color: badgeColor),
+                  BoxDecoration(shape: BoxShape.circle, color: chip),
               width: 10,
               height: 10,
             ),


### PR DESCRIPTION
```
ConvexAppBar.badge({0: '99+', 1: Icons.assistant_photo, 2: Colors.redAccent}
```

If colors are set for the badge, I think the color should be applied.