### PR TITLE
fix tabController.animateTo() bug when new index > 1 tab away

### DIFF
--- a/example/lib/default_appbar_demo.dart
+++ b/example/lib/default_appbar_demo.dart
@@ -163,11 +163,12 @@ class _State extends State<DefaultAppBarDemo>
               color: Colors.white,
               tooltip: "convex button example",
               onPressed: () => Navigator.of(context).pushNamed('/fab'),
-            ), IconButton(
-              icon: Icon(Icons.radio_button_checked),
+            ),
+            IconButton(
+              icon: Icon(Icons.looks_two),
               color: Colors.white,
               tooltip: "change tab by controller",
-              onPressed: (){
+              onPressed: () {
                 _tabController?.animateTo(2);
               },
             )
@@ -195,7 +196,11 @@ class _State extends State<DefaultAppBarDemo>
                 onTap: (int i) => debugPrint('select index=$i'),
               )
             : ConvexAppBar.badge(
-                {3: _badge!.text, 4: Icons.assistant_photo, 2: Colors.redAccent},
+                {
+                  3: _badge!.text,
+                  4: Icons.assistant_photo,
+                  2: Colors.redAccent
+                },
                 badgePadding: _badge!.padding,
                 badgeColor: _badge!.badgeColor,
                 badgeBorderRadius: _badge!.borderRadius,
@@ -221,9 +226,7 @@ class _State extends State<DefaultAppBarDemo>
     });
   }
 
-  void _onNothing(ChoiceValue<TabStyle>? value) {
-
-  }
+  void _onNothing(ChoiceValue<TabStyle>? value) {}
 
   void _onStyleChanged(ChoiceValue<TabStyle>? value) {
     if (value == null) {


### PR DESCRIPTION
Hi, this should fix #171, which was a bug introduced with the change in pull #61 to address an earlier issue #59. 
#59 appears to have been fixed in the framework itself with https://github.com/flutter/flutter/pull/88878 (in part to address TabController issue https://github.com/flutter/flutter/issues/88875) as of Flutter 2.8 (https://docs.flutter.dev/development/tools/sdk/release-notes/release-notes-2.8.0).
What do you think?

Example video of the bug, as seen in the example code:
https://user-images.githubusercontent.com/854794/182205397-fd91d5e5-c4ae-422c-8454-bed229104e61.mov
