### PR TITLE
Add Semantics() widget to tabs for accessibility

### DIFF
--- a/lib/src/style/fixed_circle_tab_style.dart
+++ b/lib/src/style/fixed_circle_tab_style.dart
@@ -73,11 +73,14 @@ class FixedCircleTabStyle extends InnerBuilder {
     var children = noLabel
         ? <Widget>[icon]
         : <Widget>[icon, Text(item.title ?? '', style: textStyle)];
-    return Container(
-      padding: EdgeInsets.only(bottom: 2),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: children,
+    return Semantics(
+      label: item.title,
+      child: Container(
+        padding: EdgeInsets.only(bottom: 2),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: children,
+        ),
       ),
     );
   }

--- a/lib/src/style/fixed_tab_style.dart
+++ b/lib/src/style/fixed_tab_style.dart
@@ -67,11 +67,14 @@ class FixedTabStyle extends InnerBuilder {
     var children = noLabel
         ? <Widget>[icon]
         : <Widget>[icon, Text(item.title ?? '', style: textStyle)];
-    return Container(
-      padding: EdgeInsets.only(bottom: 2),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.end,
-        children: children,
+    return Semantics(
+      label: item.title,
+      child: Container(
+        padding: EdgeInsets.only(bottom: 2),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: children,
+        ),
       ),
     );
   }

--- a/lib/src/style/flip_tab_style.dart
+++ b/lib/src/style/flip_tab_style.dart
@@ -75,11 +75,14 @@ class FlipTabStyle extends InnerBuilder {
         curve: curve,
       );
     }
-    return Center(
-      child: BlendImageIcon(
-        item.icon,
-        color: item.blend ? color : null,
-        size: style.iconSize,
+    return Semantics(
+      label: item.title,
+      child: Center(
+        child: BlendImageIcon(
+          item.icon,
+          color: item.blend ? color : null,
+          size: style.iconSize,
+        ),
       ),
     );
   }

--- a/lib/src/style/react_circle_tab_style.dart
+++ b/lib/src/style/react_circle_tab_style.dart
@@ -78,11 +78,14 @@ class ReactCircleTabStyle extends InnerBuilder {
     if (!noLabel) {
       children.add(Text(item.title ?? '', style: textStyle));
     }
-    return Container(
-      padding: EdgeInsets.only(bottom: 2),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: children,
+    return Semantics(
+      label: item.title,
+      child: Container(
+        padding: EdgeInsets.only(bottom: 2),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: children,
+        ),
       ),
     );
   }

--- a/lib/src/style/react_tab_style.dart
+++ b/lib/src/style/react_tab_style.dart
@@ -73,12 +73,15 @@ class ReactTabStyle extends InnerBuilder {
       children.add(Text(item.title ?? '',
           style: style.textStyle(color, item.fontFamily)));
     }
-    return Container(
-      padding: const EdgeInsets.only(bottom: 2),
-      child: Column(
-        mainAxisAlignment:
-            noLabel ? MainAxisAlignment.center : MainAxisAlignment.end,
-        children: children,
+    return Semantics(
+      label: item.title,
+      child: Container(
+        padding: const EdgeInsets.only(bottom: 2),
+        child: Column(
+          mainAxisAlignment:
+              noLabel ? MainAxisAlignment.center : MainAxisAlignment.end,
+          children: children,
+        ),
       ),
     );
   }

--- a/lib/src/style/textin_tab_style.dart
+++ b/lib/src/style/textin_tab_style.dart
@@ -63,9 +63,12 @@ class TextInTabStyle extends InnerBuilder {
       );
     }
 
-    return Center(
-      child: BlendImageIcon(item.icon,
-          size: style.iconSize, color: item.blend ? color : null),
+    return Semantics(
+      label: item.title,
+      child: Center(
+        child: BlendImageIcon(item.icon,
+            size: style.iconSize, color: item.blend ? color : null),
+      ),
     );
   }
 }

--- a/lib/src/style/titled_tab_style.dart
+++ b/lib/src/style/titled_tab_style.dart
@@ -97,6 +97,9 @@ class TitledTabStyle extends InnerBuilder {
         ],
       );
     }
-    return Center(child: Text(item.title ?? '', style: textStyle));
+    return Semantics(
+      label: item.title,
+      child: Center(child: Text(item.title ?? '', style: textStyle)),
+    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: convex_bottom_bar
 description: A Flutter package which implements a ConvexAppBar to show a convex tab in the bottom bar. Theming supported.
-version: 3.2.0
+version: 3.2.0-eh
 homepage: https://github.com/hacktons/convex_bottom_bar
 
 environment:


### PR DESCRIPTION
Add Semantics() widget to tabs to improve accessibility.
The title of the tab is used as semantic label.
This should fix #218 and other accessibility-related issues.